### PR TITLE
Added validate_certs to all post_install/os-functions

### DIFF
--- a/roles/post_install/openstack_tasks/tasks/aggregate.yml
+++ b/roles/post_install/openstack_tasks/tasks/aggregate.yml
@@ -9,4 +9,5 @@
     name: "{{ item.0.name }}"
     hosts: "{{ item.0.hosts }}"
     metadata: "{{ item.1 }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ aggregate_groups | subelements('metadata', 'skip_missing=True') }}"

--- a/roles/post_install/openstack_tasks/tasks/flavors.yml
+++ b/roles/post_install/openstack_tasks/tasks/flavors.yml
@@ -12,6 +12,7 @@
     disk: "{{ item.disk }}"
     vcpus: "{{ item.vcpus }}"
     extra_specs: "{{ item.extra_specs | default({}) }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
     state: "{{ resource_state }}"
   loop: "{{ flavors }}"
   register: reg_flavors

--- a/roles/post_install/openstack_tasks/tasks/images.yml
+++ b/roles/post_install/openstack_tasks/tasks/images.yml
@@ -20,4 +20,5 @@
     filename: "/tmp/{{ item.url | basename }}"
     is_public: yes
     properties:  "{{ item.properties|default({}) }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ images }}"

--- a/roles/post_install/openstack_tasks/tasks/instances.yml
+++ b/roles/post_install/openstack_tasks/tasks/instances.yml
@@ -18,6 +18,7 @@
     nics: "{{ item.nics }}"
     auto_ip: 'no'
     delete_fip: 'yes'
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ all_instances | flatten(levels=1) }}"
   register: reg_instance
 
@@ -33,6 +34,7 @@
     nat_destination: "{{ item.floating_ip.int_net }}"
     reuse: 'yes'
     wait: 'yes'
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ all_instances | flatten(levels=1) }}"
   when:
     - item.floating_ip is defined

--- a/roles/post_install/openstack_tasks/tasks/keypair.yml
+++ b/roles/post_install/openstack_tasks/tasks/keypair.yml
@@ -7,6 +7,7 @@
     cloud: "{{ item.cloud_name | default(cloud_name) }}"
     state: "{{ resource_state }}"
     name: "{{ item.name }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ keypairs }}"
   register: reg_keypair
 

--- a/roles/post_install/openstack_tasks/tasks/networks_and_routers.yml
+++ b/roles/post_install/openstack_tasks/tasks/networks_and_routers.yml
@@ -18,6 +18,7 @@
         provider_segmentation_id: "{{ item.segmentation_id | default(omit) }}"
         external: "{{ item.external | default('false') }}"
         shared: "{{ item.shared | default(omit) }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: present
       loop: "{{ networks }}"
 
@@ -36,6 +37,7 @@
         gateway_ip: "{{ item.gateway_ip | default(omit) }}"
         no_gateway_ip: "{{ item.no_gateway_ip  | default(omit) }}"
         ip_version: "{{ item.ip_version | default('4') }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: present
       loop: "{{ networks }}"
 
@@ -46,6 +48,7 @@
         cloud: "{{ item.cloud_name | default(cloud_name) }}"
         name: "{{ item.router_name }}"
         network: "{{ item.name }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: present
       when:
         - item.external is defined
@@ -92,6 +95,7 @@
         name: "{{ item.0.0 }}"
         interfaces: "{{ item.1 }}"
         state: present
+        validate_certs: "{{ validate_certs | default (True) }}"
       loop: "{{ routers_lists | zip(subnets_for_routers_interfaces) | list }}"
       when: routers_lists is defined
 
@@ -105,6 +109,7 @@
         vnic_type: "{{ item.1.type }}"
         security_groups: "{{ item.1.sec_groups | default(omit) }}"
         port_security_enabled: "{{ item.1.port_security | default(omit) }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: present
       loop: "{{ instances | subelements('net_ports', 'skip_missing=True') }}"
       when: net_port
@@ -120,6 +125,7 @@
         name: "{{ item.1.name }}"
         network: "{{ item.1.network }}"
         vnic_type: "{{ item.1.type }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: absent
       loop: "{{ instances | subelements('net_ports', 'skip_missing=True') }}"
       when: net_port
@@ -142,6 +148,7 @@
       os_router:
         cloud: "{{ item.cloud_name | default(cloud_name) }}"
         name: "{{ item.router_name }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: absent
       loop: "{{ networks }}"
       when:
@@ -154,6 +161,7 @@
       os_network:
         cloud: "{{ item.cloud_name | default(cloud_name) }}"
         name: "{{ item.name }}"
+        validate_certs: "{{ validate_certs | default (True) }}"
         state: absent
       loop: "{{ networks }}"
       register: delete_networks

--- a/roles/post_install/openstack_tasks/tasks/quota.yml
+++ b/roles/post_install/openstack_tasks/tasks/quota.yml
@@ -13,5 +13,6 @@
     floating_ips: "{{ item.1.floating_ips | default(omit) }}"
     fixed_ips: "{{ item.1.fixed_ips | default(omit) }}"
     state: "{{ resource_state }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ users | subelements('quota', 'skip_missing=True') }}"
   when: resource_state == 'present'

--- a/roles/post_install/openstack_tasks/tasks/security_groups.yml
+++ b/roles/post_install/openstack_tasks/tasks/security_groups.yml
@@ -6,6 +6,7 @@
   os_security_group:
     cloud: "{{ item.cloud_name | default(cloud_name) }}"
     name: "{{ item.name }}"
+    validate_certs: "{{ validate_certs | default (True) }}"
     state: "{{ resource_state }}"
   loop: "{{ security_groups }}"
   register: reg_secgroup
@@ -20,5 +21,6 @@
     port_range_min: "{{ item.1.port_range_min }}"
     port_range_max: "{{ item.1.port_range_max }}"
     remote_ip_prefix: "{{ item.1.remote_ip_prefix }}"
+    validate_certs: "{{ validate_certs | default (True) }}"
   loop: "{{ security_groups | subelements('rules', 'skip_missing=True') }}"
   when: reg_secgroup.results.0.id is defined

--- a/roles/post_install/openstack_tasks/tasks/users.yml
+++ b/roles/post_install/openstack_tasks/tasks/users.yml
@@ -10,6 +10,7 @@
     name: "{{ item.project }}"
     domain_id: "{{ item.domain }}"
     state: "{{ resource_state }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ users | flatten(levels=1) }}"
   when: item.name != 'admin'
 
@@ -23,6 +24,7 @@
     default_project: "{{ item.project }}"
     domain: "{{ item.domain }}"
     state: "{{ resource_state }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ users | flatten(levels=1) }}"
   register: reg_users
   when: item.name != 'admin'
@@ -36,6 +38,7 @@
     project: "{{ item.project }}"
     role: "{{ item.role }}"
     state: "{{ resource_state }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
   loop: "{{ users | flatten(levels=1) }}"
   when:
     - reg_users.changed

--- a/roles/post_install/openstack_tasks/tasks/volumes.yml
+++ b/roles/post_install/openstack_tasks/tasks/volumes.yml
@@ -8,6 +8,7 @@
     availability_zone: "{{ item.availability_zone }}"
     size: "{{ item.size }}"
     display_name: "{{ item.name }}"
+    validate_certs: "{{ validate_certs | default(True) }}"
     scheduler_hints:
       same_host: "{{ item.name | replace('dynamicvolume', 'dynamicinstance') }}"
       when: ephemeral | default(False)


### PR DESCRIPTION
Using the test with a tripleo-quickstart deployment, I got the error like
"keystoneauth1.exceptions.discovery.DiscoveryFailure: Could not find versioned identity endpoints when attempting to authenticate. Please check that your auth_url is correct. SSL exception connecting to https://10.0.0.5:13000: HTTPSConnectionPool(host=10.0.0.5, port=13000): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:897)),))"

So adding the validate_certs=False on the parameters bypass the error