### PR TITLE
Set tuned cpu-partitioning profile in DuT compute

### DIFF
--- a/roles/packet_gen/trex/compute_tuning/defaults/main.yml
+++ b/roles/packet_gen/trex/compute_tuning/defaults/main.yml
@@ -1,0 +1,1 @@
+set_tuned_cpu_partitioning: true

--- a/roles/packet_gen/trex/compute_tuning/tasks/main.yml
+++ b/roles/packet_gen/trex/compute_tuning/tasks/main.yml
@@ -13,3 +13,8 @@
 - name: Query multiqueue value
   import_tasks: query_multiqueue.yml
   when: multiqueue_set is defined and  multiqueue_set
+
+- name: Set tuned cpu-partitioning profile
+  import_tasks: set_tuned_cpu_partitioning.yml
+  when: "{{ ansible_processor is contains('GenuineIntel') and
+        set_tuned_cpu_partitioning is defined and set_tuned_cpu_partitioning }}"

--- a/roles/packet_gen/trex/compute_tuning/tasks/set_tuned_cpu_partitioning.yml
+++ b/roles/packet_gen/trex/compute_tuning/tasks/set_tuned_cpu_partitioning.yml
@@ -1,0 +1,25 @@
+- name: Get tuned profile
+  ansible.builtin.command: tuned-adm active
+  register: tuned_active_profile
+  changed_when: false
+  check_mode: no
+
+- name: Parse the active profile name from the command output
+  ansible.builtin.set_fact:
+    tuned_active_profile: "{{ tuned_active_profile.stdout.split(':')[1] | trim }}"
+
+- name: Display the tuned active profile
+  ansible.builtin.debug:
+    msg: "Active tuned profile: {{ tuned_active_profile }}"
+
+- name: Set tuned cpu-partitioning profile
+  become: true
+  block:
+    - name: Set tuned cpu-partitioning profile
+      ansible.builtin.command: tuned-adm profile cpu-partitioning
+
+    - name: Restart tuned service
+      ansible.builtin.service:
+        name: tuned
+        state: restarted
+  when: tuned_active_profile != 'cpu-partitioning'


### PR DESCRIPTION
DPDK performance number is impacted in case we have the cpu-partitioning-powersave profile set in tuned.
For details see:
 https://issues.redhat.com/browse/OSPRH-17862