### PR TITLE
Enable P-state turbo for tuned cpu-partitioning-powersave profile

### DIFF
--- a/roles/packet_gen/trex/compute_tuning/defaults/main.yml
+++ b/roles/packet_gen/trex/compute_tuning/defaults/main.yml
@@ -1,0 +1,1 @@
+tuned_enable_pstate_turbo: true

--- a/roles/packet_gen/trex/compute_tuning/tasks/main.yml
+++ b/roles/packet_gen/trex/compute_tuning/tasks/main.yml
@@ -13,3 +13,7 @@
 - name: Query multiqueue value
   import_tasks: query_multiqueue.yml
   when: multiqueue_set is defined and  multiqueue_set
+
+- name: Enable P-state turbo
+  import_tasks: tuned_enable_pstate_turbo.yml
+  when: tuned_enable_pstate_turbo is defined and tuned_enable_pstate_turbo

--- a/roles/packet_gen/trex/compute_tuning/tasks/tuned_enable_pstate_turbo.yml
+++ b/roles/packet_gen/trex/compute_tuning/tasks/tuned_enable_pstate_turbo.yml
@@ -1,0 +1,28 @@
+- name: Get tuned profile
+  ansible.builtin.command: tuned-adm active
+  register: tuned_active_profile
+  changed_when: false
+  check_mode: no
+
+- name: Parse the active profile name from the command output
+  ansible.builtin.set_fact:
+    tuned_active_profile: "{{ tuned_active_profile.stdout.split(':')[1] | trim }}"
+
+- name: Display the tuned active profile
+  ansible.builtin.debug:
+    msg: "Active tuned profile: {{ tuned_active_profile }}"
+
+- name: Enable P-state turbo in tuned cpu-partitioning-powersave profile
+  become: true
+  block:
+    - name: Set no_turbo to false in /usr/lib/tuned/cpu-partitioning-powersave/tuned.conf
+      ansible.builtin.lineinfile:
+       dest: /usr/lib/tuned/cpu-partitioning-powersave/tuned.conf
+       regexp: '^no_turbo='
+       line: 'no_turbo=false'
+    - name: Restart tuned service
+      ansible.builtin.service:
+        name: tuned
+        state: restarted
+  when: "{{ ansible_processor is contains('GenuineIntel') and
+        tuned_enable_pstate_turbo is defined and tuned_enable_pstate_turbo }}"


### PR DESCRIPTION
DPDK performance number is impacted if we have no_turbo=true in the cpu-partitioning-powersave profile of tuned. For details see: https://issues.redhat.com/browse/OSPRH-17862