### PR TITLE
Fix connection leak on early SIGINT in multiqueue

### DIFF
--- a/roles/packet_gen/trex/multiqueue/files/multiqueue.py
+++ b/roles/packet_gen/trex/multiqueue/files/multiqueue.py
@@ -316,6 +316,7 @@ def gen_stl(devices, traffic, duration, multiplier):
     param multiplier: multiply to each pps to increase rate
     """
     c = STLClient(verbose_level="error")
+    my_ports = []
 
     def signal_handler(sig, frame):
         c.stop(ports=my_ports)


### PR DESCRIPTION
## Summary
- Initialize `my_ports = []` before registering the signal handler in `gen_stl()` to prevent a `NameError` that would skip `c.disconnect()` and leak the TRex client connection when SIGINT arrives before port assignment.

## Test plan
- [ ] Send SIGINT to `multiqueue.py --action gen_traffic` immediately after launch and verify TRex client disconnects cleanly
- [ ] Run normal `gen_traffic` flow end-to-end to confirm no regression

Co-Authored-By: Claude noreply@anthropic.com