### PR TITLE
Fix mount leak in get_tag() when metadata read fails

### DIFF
--- a/roles/post_install/openstack_tasks/files/custom_net_config.py
+++ b/roles/post_install/openstack_tasks/files/custom_net_config.py
@@ -175,12 +175,15 @@ def get_tag():
     try:
         config_drive = execute_shell_command('mount /dev/sr0 /mnt')
         logger.info(config_drive)
-        with open('/mnt/openstack/latest/meta_data.json') as json_file:
-            metadata = json.load(json_file)
-        execute_shell_command('umount /mnt')
-        logger.info('Config drive unmounted')
-    except ValueError:
+        try:
+            with open('/mnt/openstack/latest/meta_data.json') as json_file:
+                metadata = json.load(json_file)
+        finally:
+            execute_shell_command('umount /mnt')
+            logger.info('Config drive unmounted')
+    except (ValueError, subprocess.CalledProcessError):
         logger.info('Unable to mount config drive or fetch metadata.')
+        return None
 
     metadata = metadata['devices']
     for meta in metadata:


### PR DESCRIPTION
## Summary
- Ensure `/dev/sr0` is unmounted via `try/finally` after a successful mount, even if `json.load` fails
- Return `None` on failure instead of falling through to access an unbound `metadata` variable
- Catch `subprocess.CalledProcessError` in addition to `ValueError`

## Test plan
- [ ] Simulate a corrupted `meta_data.json` and verify `/dev/sr0` is unmounted
- [ ] Verify normal boot path with valid metadata still works

Co-Authored-By: Claude noreply@anthropic.com