### PR TITLE
Fix multiplier passed as isg in create_stream call

### DIFF
--- a/roles/packet_gen/trex/multiqueue/files/multiqueue.py
+++ b/roles/packet_gen/trex/multiqueue/files/multiqueue.py
@@ -301,7 +301,7 @@ class STLImix(object):
                 streams.append(self.create_stream(float(qratio[queue]["pps"]),
                                                   vm, src_mac, dst_mac, src_ip,
                                                   dst_ip, src_port, dst_port,
-                                                  multiplier))
+                                                  multiplier=multiplier))
         return streams
 
 


### PR DESCRIPTION
## Summary
- `multiplier` was passed positionally to `create_stream()`, landing in the `isg` parameter slot — so the actual multiplier was always the default `1`
- Pass `multiplier` as a keyword argument to fix the bug

## Test plan
- [ ] Run `gen_traffic` with `--multiplier > 1` and verify traffic rate scales accordingly

Co-Authored-By: Claude noreply@anthropic.com